### PR TITLE
[USER] 로그인, 로그아웃, JWT 발급/검증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/web/seminar/config/SecurityConfig.java
+++ b/src/main/java/web/seminar/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -19,6 +21,11 @@ public class SecurityConfig {
                 .and().authorizeHttpRequests()
                 .anyRequest().permitAll();
         return httpSecurity.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
     }
 
 }

--- a/src/main/java/web/seminar/config/WebConfig.java
+++ b/src/main/java/web/seminar/config/WebConfig.java
@@ -1,0 +1,20 @@
+package web.seminar.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import web.seminar.config.authentication.AuthUserArgumentResolver;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolverList){
+        argumentResolverList.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/web/seminar/config/authentication/AuthUser.java
+++ b/src/main/java/web/seminar/config/authentication/AuthUser.java
@@ -1,0 +1,12 @@
+package web.seminar.config.authentication;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface AuthUser {
+    boolean required() default true;
+}

--- a/src/main/java/web/seminar/config/authentication/AuthUserArgumentResolver.java
+++ b/src/main/java/web/seminar/config/authentication/AuthUserArgumentResolver.java
@@ -1,0 +1,39 @@
+package web.seminar.config.authentication;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import web.seminar.domain.entity.User;
+import web.seminar.service.JwtService;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtService jwtService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        AuthUser authUserAnnotation = parameter.getParameterAnnotation(AuthUser.class);
+        assert authUserAnnotation != null;
+        if(!authUserAnnotation.required()){
+            throw new IllegalArgumentException("올바르지 않은 접근입니다. 헤더를 확인해주세요.");
+        }
+
+        Authentication authentication = jwtService.getAuthenticationFromRequest(Objects.requireNonNull(webRequest.getNativeRequest(HttpServletRequest.class)));
+        return (User) authentication.getPrincipal();
+    }
+}

--- a/src/main/java/web/seminar/controller/UserController.java
+++ b/src/main/java/web/seminar/controller/UserController.java
@@ -3,12 +3,14 @@ package web.seminar.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import web.seminar.controller.dto.SignInDTO;
 import web.seminar.controller.dto.SignUpDTO;
 import web.seminar.domain.entity.User;
+import web.seminar.service.JwtService;
 import web.seminar.service.UserService;
 
 @RestController
@@ -16,7 +18,9 @@ import web.seminar.service.UserService;
 @RequestMapping("/users")
 public class UserController {
     private final UserService userService;
+    private final JwtService jwtService;
 
+    @PostMapping("/register")
     public ResponseEntity<?> signUp(@RequestBody SignUpDTO signUpDTO){
         User user = userService.addUser(signUpDTO);
         if(user.getUserId() == null) {
@@ -24,9 +28,10 @@ public class UserController {
         }
         return new ResponseEntity<>("회원가입에 성공하였습니다.", HttpStatus.CREATED);
     }
-
+    @PostMapping("/login")
     public ResponseEntity<?> signIn(@RequestBody SignInDTO signInDTO){
-        String authToken = userService.findUser(signInDTO);
+        User user = userService.findUser(signInDTO);
+        String authToken = jwtService.createAccessToken(user.getUserId());
         return new ResponseEntity<>(authToken, HttpStatus.OK);
     }
 }

--- a/src/main/java/web/seminar/controller/UserController.java
+++ b/src/main/java/web/seminar/controller/UserController.java
@@ -1,0 +1,26 @@
+package web.seminar.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import web.seminar.controller.dto.SignUpDTO;
+import web.seminar.domain.entity.User;
+import web.seminar.service.UserService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+    private final UserService userService;
+
+    public ResponseEntity<?> signUp(@RequestBody SignUpDTO signUpDTO){
+        User user = userService.addUser(signUpDTO);
+        if(user.getUserId() == null){
+            return new ResponseEntity<>("에러가 발생했습니다.", HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<>("회원가입에 성공하였습니다.", HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/web/seminar/controller/UserController.java
+++ b/src/main/java/web/seminar/controller/UserController.java
@@ -3,10 +3,8 @@ package web.seminar.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import web.seminar.config.authentication.AuthUser;
 import web.seminar.controller.dto.SignInDTO;
 import web.seminar.controller.dto.SignUpDTO;
 import web.seminar.domain.entity.User;
@@ -28,10 +26,16 @@ public class UserController {
         }
         return new ResponseEntity<>("회원가입에 성공하였습니다.", HttpStatus.CREATED);
     }
+
     @PostMapping("/login")
     public ResponseEntity<?> signIn(@RequestBody SignInDTO signInDTO){
         User user = userService.findUser(signInDTO);
         String authToken = jwtService.createAccessToken(user.getUserId());
         return new ResponseEntity<>(authToken, HttpStatus.OK);
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<?> test(@AuthUser User user){
+        return new ResponseEntity<>(user, HttpStatus.OK);
     }
 }

--- a/src/main/java/web/seminar/controller/UserController.java
+++ b/src/main/java/web/seminar/controller/UserController.java
@@ -17,6 +17,7 @@ public class UserController {
     private final UserService userService;
 
     public ResponseEntity<?> signUp(@RequestBody SignUpDTO signUpDTO){
+
         User user = userService.addUser(signUpDTO);
         if(user.getUserId() == null){
             return new ResponseEntity<>("에러가 발생했습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/web/seminar/controller/UserController.java
+++ b/src/main/java/web/seminar/controller/UserController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import web.seminar.controller.dto.SignInDTO;
 import web.seminar.controller.dto.SignUpDTO;
 import web.seminar.domain.entity.User;
 import web.seminar.service.UserService;
@@ -17,11 +18,15 @@ public class UserController {
     private final UserService userService;
 
     public ResponseEntity<?> signUp(@RequestBody SignUpDTO signUpDTO){
-
         User user = userService.addUser(signUpDTO);
-        if(user.getUserId() == null){
+        if(user.getUserId() == null) {
             return new ResponseEntity<>("에러가 발생했습니다.", HttpStatus.BAD_REQUEST);
         }
         return new ResponseEntity<>("회원가입에 성공하였습니다.", HttpStatus.CREATED);
+    }
+
+    public ResponseEntity<?> signIn(@RequestBody SignInDTO signInDTO){
+        String authToken = userService.findUser(signInDTO);
+        return new ResponseEntity<>(authToken, HttpStatus.OK);
     }
 }

--- a/src/main/java/web/seminar/controller/dto/SignInDTO.java
+++ b/src/main/java/web/seminar/controller/dto/SignInDTO.java
@@ -1,0 +1,9 @@
+package web.seminar.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignInDTO {
+    public String userName;
+    public String password;
+}

--- a/src/main/java/web/seminar/controller/dto/SignUpDTO.java
+++ b/src/main/java/web/seminar/controller/dto/SignUpDTO.java
@@ -1,0 +1,10 @@
+package web.seminar.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SignUpDTO {
+    public String userName;
+    public String password;
+    public String nickname;
+}

--- a/src/main/java/web/seminar/domain/entity/User.java
+++ b/src/main/java/web/seminar/domain/entity/User.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -31,4 +32,9 @@ public class User {
         this.password = password;
         this.nickname = nickname;
     }
+
+    public boolean isCorrectPassword(User user){
+        return Objects.equals(user.getPassword(), this.password);
+    }
+
 }

--- a/src/main/java/web/seminar/domain/entity/User.java
+++ b/src/main/java/web/seminar/domain/entity/User.java
@@ -33,8 +33,4 @@ public class User {
         this.nickname = nickname;
     }
 
-    public boolean isCorrectPassword(User user){
-        return Objects.equals(user.getPassword(), this.password);
-    }
-
 }

--- a/src/main/java/web/seminar/domain/repository/UserRepository.java
+++ b/src/main/java/web/seminar/domain/repository/UserRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import web.seminar.domain.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUserName(String userName);
 }

--- a/src/main/java/web/seminar/domain/repository/UserRepository.java
+++ b/src/main/java/web/seminar/domain/repository/UserRepository.java
@@ -3,6 +3,8 @@ package web.seminar.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import web.seminar.domain.entity.User;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
-    User findByUserName(String userName);
+    Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/web/seminar/exception/UserExistedException.java
+++ b/src/main/java/web/seminar/exception/UserExistedException.java
@@ -1,0 +1,7 @@
+package web.seminar.exception;
+
+public class UserExistedException extends IllegalArgumentException{
+    public UserExistedException(){
+        super("이미 존재하는 유저입니다.");
+    }
+}

--- a/src/main/java/web/seminar/service/JwtService.java
+++ b/src/main/java/web/seminar/service/JwtService.java
@@ -49,17 +49,11 @@ public class JwtService {
         return this.createToken(userId.toString(), accessTokenValidTime);
     }
 
-    public String resolveAccessToken(HttpServletRequest request){
-        return request.getHeader("Authorization");
-    }
-
-    public Long getMemberInfo(String token) {
-        return Long.valueOf(Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody().getSubject());
-    }
-
-    public Authentication getAuthentication(String token){
-        User user = userRepository.findById(getMemberInfo(token))
-                .orElseThrow(() -> new IllegalArgumentException("토큰으로 유저 정보를 확인할 수 없습니다."));
+    public Authentication getAuthenticationFromRequest(HttpServletRequest request){
+        String token = request.getHeader("Authorization");
+        Long userId  = Long.valueOf(Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody().getSubject());
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
         return new UsernamePasswordAuthenticationToken(user, "");
     }
 

--- a/src/main/java/web/seminar/service/JwtService.java
+++ b/src/main/java/web/seminar/service/JwtService.java
@@ -1,0 +1,75 @@
+package web.seminar.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import web.seminar.domain.entity.User;
+import web.seminar.domain.repository.UserRepository;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Slf4j
+@Service
+public class JwtService {
+    private final UserRepository userRepository;
+
+    @Value("${spring.jwt.secret-key}")
+    private String SECRET_KEY;
+
+    private Long accessTokenValidTime = 1000L * 60 * 60 * 24;
+
+    @PostConstruct
+    protected void init(){
+        SECRET_KEY = Base64.getEncoder().encodeToString(SECRET_KEY.getBytes());
+    }
+
+    public String createToken(String value, Long tokenValidTime){
+        Claims claims = Jwts.claims().setSubject(value);
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenValidTime))
+                .signWith(SignatureAlgorithm.HS256, SECRET_KEY)
+                .compact();
+    }
+
+    public String createAccessToken(Long userId){
+        return this.createToken(userId.toString(), accessTokenValidTime);
+    }
+
+    public String resolveAccessToken(HttpServletRequest request){
+        return request.getHeader("Authorization");
+    }
+
+    public Long getMemberInfo(String token) {
+        return Long.valueOf(Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(token).getBody().getSubject());
+    }
+
+    public Authentication getAuthentication(String token){
+        User user = userRepository.findById(getMemberInfo(token))
+                .orElseThrow(() -> new IllegalArgumentException("토큰으로 유저 정보를 확인할 수 없습니다."));
+        return new UsernamePasswordAuthenticationToken(user, "");
+    }
+
+    public boolean validateToken(String jwtToken){
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(SECRET_KEY).parseClaimsJws(jwtToken);
+            return claims.getBody().getExpiration().after(new Date());
+        }
+        catch (Exception e){
+            return false;
+        }
+    }
+}

--- a/src/main/java/web/seminar/service/UserService.java
+++ b/src/main/java/web/seminar/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import web.seminar.controller.dto.SignUpDTO;
 import web.seminar.domain.entity.User;
 import web.seminar.domain.repository.UserRepository;
+import web.seminar.exception.UserExistedException;
 
 @RequiredArgsConstructor
 @Service
@@ -14,7 +15,11 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public User addUser(SignUpDTO signUpDTO) {
-        User user = userRepository.save(
+        User user = userRepository.findByUserName(signUpDTO.getUserName());
+        if(user != null){
+            throw new UserExistedException();
+        }
+        user = userRepository.save(
                 User.builder()
                         .userName(signUpDTO.getUserName())
                         .password(passwordEncoder.encode((signUpDTO.getPassword())))

--- a/src/main/java/web/seminar/service/UserService.java
+++ b/src/main/java/web/seminar/service/UserService.java
@@ -3,6 +3,7 @@ package web.seminar.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import web.seminar.controller.dto.SignInDTO;
 import web.seminar.controller.dto.SignUpDTO;
 import web.seminar.domain.entity.User;
@@ -17,6 +18,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public User addUser(SignUpDTO signUpDTO) {
         Optional<User> user = userRepository.findByUserName(signUpDTO.getUserName());
         if(user.isPresent()){
@@ -31,11 +33,11 @@ public class UserService {
         );
     }
 
+    @Transactional
     public User findUser(SignInDTO signInDTO) {
         User user = userRepository.findByUserName(signInDTO.getUserName())
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 사용자입니다."));
-
-        if(!user.isCorrectPassword(user)){
+        if(!passwordEncoder.matches(user.getPassword(), signInDTO.getPassword())) {
             throw new IllegalArgumentException("패스워드가 올바르지 않습니다.");
         }
         return user;

--- a/src/main/java/web/seminar/service/UserService.java
+++ b/src/main/java/web/seminar/service/UserService.java
@@ -1,0 +1,23 @@
+package web.seminar.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import web.seminar.controller.dto.SignUpDTO;
+import web.seminar.domain.entity.User;
+import web.seminar.domain.repository.UserRepository;
+
+@RequiredArgsConstructor
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    public User addUser(SignUpDTO signUpDTO) {
+        User user = userRepository.save(
+                User.builder()
+                        .userName(signUpDTO.getUserName())
+                        .password(signUpDTO.getPassword())
+                        .nickname(signUpDTO.getNickname())
+                        .build()
+        );
+        return user;
+    }
+}

--- a/src/main/java/web/seminar/service/UserService.java
+++ b/src/main/java/web/seminar/service/UserService.java
@@ -3,10 +3,13 @@ package web.seminar.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import web.seminar.controller.dto.SignInDTO;
 import web.seminar.controller.dto.SignUpDTO;
 import web.seminar.domain.entity.User;
 import web.seminar.domain.repository.UserRepository;
 import web.seminar.exception.UserExistedException;
+
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -15,17 +18,21 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     public User addUser(SignUpDTO signUpDTO) {
-        User user = userRepository.findByUserName(signUpDTO.getUserName());
-        if(user != null){
+        Optional<User> user = userRepository.findByUserName(signUpDTO.getUserName());
+        if(user.isPresent()){
             throw new UserExistedException();
         }
-        user = userRepository.save(
+        return userRepository.save(
                 User.builder()
                         .userName(signUpDTO.getUserName())
                         .password(passwordEncoder.encode((signUpDTO.getPassword())))
                         .nickname(signUpDTO.getNickname())
                         .build()
         );
-        return user;
+    }
+
+    public String findUser(SignInDTO signInDTO) {
+
+        return "";
     }
 }

--- a/src/main/java/web/seminar/service/UserService.java
+++ b/src/main/java/web/seminar/service/UserService.java
@@ -1,6 +1,7 @@
 package web.seminar.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import web.seminar.controller.dto.SignUpDTO;
 import web.seminar.domain.entity.User;
@@ -10,11 +11,13 @@ import web.seminar.domain.repository.UserRepository;
 @Service
 public class UserService {
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
     public User addUser(SignUpDTO signUpDTO) {
         User user = userRepository.save(
                 User.builder()
                         .userName(signUpDTO.getUserName())
-                        .password(signUpDTO.getPassword())
+                        .password(passwordEncoder.encode((signUpDTO.getPassword())))
                         .nickname(signUpDTO.getNickname())
                         .build()
         );

--- a/src/main/java/web/seminar/service/UserService.java
+++ b/src/main/java/web/seminar/service/UserService.java
@@ -31,8 +31,13 @@ public class UserService {
         );
     }
 
-    public String findUser(SignInDTO signInDTO) {
+    public User findUser(SignInDTO signInDTO) {
+        User user = userRepository.findByUserName(signInDTO.getUserName())
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 사용자입니다."));
 
-        return "";
+        if(!user.isCorrectPassword(user)){
+            throw new IllegalArgumentException("패스워드가 올바르지 않습니다.");
+        }
+        return user;
     }
 }

--- a/src/main/java/web/seminar/service/UserService.java
+++ b/src/main/java/web/seminar/service/UserService.java
@@ -37,7 +37,8 @@ public class UserService {
     public User findUser(SignInDTO signInDTO) {
         User user = userRepository.findByUserName(signInDTO.getUserName())
                 .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 사용자입니다."));
-        if(!passwordEncoder.matches(user.getPassword(), signInDTO.getPassword())) {
+
+        if(!passwordEncoder.matches(signInDTO.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("패스워드가 올바르지 않습니다.");
         }
         return user;


### PR DESCRIPTION
# 기능
## 1. 회원가입 `users/register`
[HTTP REQUEST]
```json
{
    "userName":"sunny",
    "password":"12345678901",
    "nickname":"sunny lee"
}
```
[HTTP RESPONSE]
```json
{
    "회원가입에 성공하였습니다."
}
```
- 이외 예외처리

## 2. 로그인 `users/login`
[HTTP REQUEST]
```json
{
    "userName":"sunny",
    "password":"12345678901"
}
```
[HTTP RESPONSE]
```json
{
    // 바디에 토큰 발급
}
```
- 이외 예외처리

## 3. 토큰 발급/자동화 `users/test`
```java
@GetMapping("/test")
    public ResponseEntity<?> test(@AuthUser User user){
        return new ResponseEntity<>(user, HttpStatus.OK);
    }
```
- 위와 같이 파라미터에 `@AuthUser` 어노테이션을 달면 자동으로 JWT 토큰을 Resolve합니다.
- 개발 편의상 JwtFilter는 후에 추가하겠습니다.
- 코드 리뷰 하실 때 `config/authentication`에서 효율성 괜찮은지, 줄일 수 있는 코드 있는지 봐주시면 감사하겠습니다.


# 관련 이슈
#2 

- api 문서는 확인 후 추가하도록 하겠습니다.